### PR TITLE
fix: compile under Nix flake on macOS

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,10 @@
       let 
         pkgs = import nixpkgs { inherit system overlays; };
         nativeBuildInputs = with pkgs; [ pkg-config ];
-        buildInputs = with pkgs; [ openssl ];
+        buildInputs = with pkgs; [ openssl ] ++
+                                 lib.optionals pkgs.stdenv.isDarwin [
+                                   pkgs.darwin.apple_sdk.frameworks.SystemConfiguration
+                                 ];
       in
       {
         devShells = {


### PR DESCRIPTION
see https://github.com/mthom/scryer-prolog/pull/2768